### PR TITLE
Remove s2geometry pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
     - 0001-fix-cmake.patch
 
 build:
-  number: 2
-  skip: true  # [py<39]
+  number: 3
   script: {{ PYTHON }} -m pip install . --no-deps -vv --ignore-installed --no-cache-dir --no-build-isolation
 
 requirements:
@@ -33,10 +32,9 @@ requirements:
     - pip
     - scikit-build-core
     - numpy
-    - s2geometry >=0.10.0
+    - s2geometry
   run:
     - python
-    - {{ pin_compatible('s2geometry', max_pin='x.x') }}
 
 test:
   source_files:


### PR DESCRIPTION
S2Geometry is now a globally pinned package in conda-forge and defines `run_exports` (https://github.com/conda-forge/s2geometry-feedstock/pull/20) that we should use here.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
